### PR TITLE
render cell when value equals `false`

### DIFF
--- a/src/jsonTable.ts
+++ b/src/jsonTable.ts
@@ -156,7 +156,7 @@ export class JSONTable {
         let i = 0;
         for (let attr of partialHeader.attrs) {
             let value = this.getByPath(attr, partialJson);
-            if (value) {
+            if (value || value === false) {
                 this.divs.push({
                     row: rowBase,
                     column: columnBase + i,


### PR DESCRIPTION
test required

<img width="167" alt="image" src="https://user-images.githubusercontent.com/9448115/229973694-9c0be64d-e222-43da-ad8a-eec371fc856d.png">

As you can see, the boolean value did not render well. So we can fix it, and more tests are needed.